### PR TITLE
Add node 24 prebuilds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
           - os: windows-2019
             label: x86
             node_arch: x86
-            command: build:gyp
+            command: build:gyp:x86
           # Windows x64
           - os: windows-2019
             label: x64
@@ -64,23 +64,6 @@ jobs:
             command: build:gyp-cross
             args: --tag-libc musl -i linux-arm64-musl
           - os: ubuntu-22.04
-            label: arm64+armv7
-            command: build:gyp-cross
-            args: -i android-arm64 -i android-armv7
-          # Ubuntu 24.04
-          - os: ubuntu-24.04
-            label: alpine
-            command: build:gyp-cross
-            args: -i centos7-devtoolset7 -i alpine
-          - os: ubuntu-24.04
-            label: armv6+armv7
-            command: build:gyp-cross
-            args: -i linux-arm64-lts -i linux-armv7 -i linux-armv6
-          - os: ubuntu-24.04
-            label: musl+arm64-musl
-            command: build:gyp-cross
-            args: --tag-libc musl -i linux-arm64-musl
-          - os: ubuntu-24.04
             label: arm64+armv7
             command: build:gyp-cross
             args: -i android-arm64 -i android-armv7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,32 +15,72 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-12
-            label: x64+arm64
+          # Intel Mac
+          - os: macos-13
+            label: x64
             node_arch: x64
             command: build:gyp
-            args: --arch x64+arm64
+            args: --arch x64
+          # Arm64 Mac
+          - os: macos-14
+            label: arm64
+            node_arch: arm64
+            command: build:gyp
+            args: --arch arm64
+          - os: macos-15
+            label: arm64
+            node_arch: arm64
+            command: build:gyp
+            args: --arch arm64
+          # Windows x86
           - os: windows-2019
             label: x86
             node_arch: x86
             command: build:gyp
+          # Windows x64
           - os: windows-2019
             label: x64
             node_arch: x64
             command: build:gyp
-          - os: ubuntu-20.04
+          - os: windows-2022
+            label: x64
+            node_arch: x64
+            command: build:gyp
+          - os: windows-2025
+            label: x64
+            node_arch: x64
+            command: build:gyp
+          # Ubuntu 22.04
+          - os: ubuntu-22.04
             label: alpine
             command: build:gyp-cross
             args: -i centos7-devtoolset7 -i alpine
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             label: armv6+armv7
             command: build:gyp-cross
             args: -i linux-arm64-lts -i linux-armv7 -i linux-armv6
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             label: musl+arm64-musl
             command: build:gyp-cross
             args: --tag-libc musl -i linux-arm64-musl
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
+            label: arm64+armv7
+            command: build:gyp-cross
+            args: -i android-arm64 -i android-armv7
+          # Ubuntu 24.04
+          - os: ubuntu-24.04
+            label: alpine
+            command: build:gyp-cross
+            args: -i centos7-devtoolset7 -i alpine
+          - os: ubuntu-24.04
+            label: armv6+armv7
+            command: build:gyp-cross
+            args: -i linux-arm64-lts -i linux-armv7 -i linux-armv6
+          - os: ubuntu-24.04
+            label: musl+arm64-musl
+            command: build:gyp-cross
+            args: --tag-libc musl -i linux-arm64-musl
+          - os: ubuntu-24.04
             label: arm64+armv7
             command: build:gyp-cross
             args: -i android-arm64 -i android-armv7

--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
   ],
   "scripts": {
     "semantic-release": "semantic-release",
-    "build:gyp": "prebuildify --napi false --strip --target 10.24.1 --target 12.22.12 --target 14.21.3 --target 16.20.2 --target 18.17.1 --target 19.9.0 --target 20.12.2 --target 21.7.3 --target 22.11.0",
-    "build:gyp-cross": "prebuildify-cross --napi false --strip --target 10.24.1 --target 12.22.12 --target 14.21.3 --target 16.20.2 --target 18.17.1 --target 19.9.0 --target 20.12.2 --target 21.7.3 --target 22.11.0",
+    "build:gyp:x86": "prebuildify --napi false --strip --target 10.24.1 --target 12.22.12 --target 14.21.3 --target 16.20.2 --target 18.17.1 --target 19.9.0 --target 20.12.2 --target 21.7.3 --target 22.11.0",
+    "build:gyp": "prebuildify --napi false --strip --target 10.24.1 --target 12.22.12 --target 14.21.3 --target 16.20.2 --target 18.17.1 --target 19.9.0 --target 20.12.2 --target 21.7.3 --target 22.11.0 --target 24.0.0",
+    "build:gyp-cross": "prebuildify-cross --napi false --strip --target 10.24.1 --target 12.22.12 --target 14.21.3 --target 16.20.2 --target 18.17.1 --target 19.9.0 --target 20.12.2 --target 21.7.3 --target 22.11.0 --target 24.0.0",
     "install": "node-gyp-build"
   },
   "repository": {


### PR DESCRIPTION
Per the [Standard GitHub-hosted runners for public repositories](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#standard-github-hosted-runners-for-public-repositories), updated the OS versions. Left the Windows x86 version. Split x64 and arm64 versions of MacOS as `--arch x64+arm64` only passes the first architecture (x64) to `prebuildify`.
> The arch option can also be a multi-arch value separated by + (for example x64+arm64 for a [universal binary](https://en.wikipedia.org/wiki/Universal_binary)) mainly to dictate the output folder; **only the first architecture is passed on to node-gyp**.
- Replaced Intel Mac OS `macos-12` with Intel Mac OS `macos-13`
- Split out arm64 Mac
  - Added arm64 Mac `macos-14`
  - Added arm64 Mac `macos-15`
- Left Windows x86 `windows-2019` (separate prebuild script - not supported by node 24)
- Left Windows x64 `windows-2019`
- Added Windows x64 `windows-2022`
- Added Windows x64 `windows-2025`
- Removed Ubuntu 20.04: EOL May 2025
- Added Ubuntu 22.04: LTS
~~- Added Ubuntu 24.04: LTS~~
